### PR TITLE
Add Example.Console 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ dotnet cake --lang="csharp" --ui="wpf" --license-key="your_license_key"
 
  - `--license-key` Required. The license key used for launching the application.
  - `--lang` Optional. Can be either `csharp` or `vbnet`. The default value is `csharp`.
- - `--ui` Optional. Can be either `wpf` or `winforms`. The default value is `wpf`.
+ - `--ui` Optional. Can be either `console`, `wpf`, or `winforms`. The default value is `console`.

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 var target = Argument("target", "Run");
 var lang = Argument("lang", "csharp");
-var ui = Argument("ui", "wpf");
+var ui = Argument("ui", "console");
 var licenseKey = Argument("license-key", "");
 
 //////////////////////////////////////////////////////////////////////
@@ -13,9 +13,9 @@ Setup(setupContext =>
     {
         throw new Exception("The --lang argument should be set to either \"csharp\" or \"vbnet\".");
     }
-    if (ui != "wpf" && ui != "winforms")
+    if (ui != "wpf" && ui != "winforms" && ui != "console")
     {
-        throw new Exception("The --ui argument should be set to either \"wpf\" or \"winforms\".");
+        throw new Exception("The --ui argument should be set to either \"console\", \"wpf\", or \"winforms\".");
     }
     if (string.IsNullOrWhiteSpace(licenseKey))
     {
@@ -52,16 +52,16 @@ Task("Run")
     .IsDependentOn("Build")
     .Does(() =>
 {
-    var path = new FilePath($"./{lang}/embedding.{ui}/bin/Release/netcoreapp3.1/embedding.{ui}.exe").MakeAbsolute(Context.Environment);
-
-    var settings = new ProcessSettings {
-        RedirectStandardOutput = true,
-        RedirectStandardError = true,
-        WorkingDirectory = path.GetDirectory()
+    var project = ui == "console" ? "example.console" : $"embedding.{ui}" ;
+    var path = $"./{lang}/{project}";
+    var settings = new DotNetRunSettings
+    {
+        Configuration = "Release"
     };
     settings.EnvironmentVariables= new Dictionary<string, string>(){{"DOTNETBROWSER_LICENSE", licenseKey}};
     Information($"Launching {path}");
-    StartProcess(path, settings);
+    
+    DotNetRun(path, settings);
 });
 
 //////////////////////////////////////////////////////////////////////

--- a/csharp/DotNetBrowser.QuickStart.sln
+++ b/csharp/DotNetBrowser.QuickStart.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31829.152
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Embedding.WinForms", "Embedding.WinForms\Embedding.WinForms.csproj", "{24C6C334-A4CF-4867-BA13-D45E5B2A8827}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Embedding.WinForms", "Embedding.WinForms\Embedding.WinForms.csproj", "{24C6C334-A4CF-4867-BA13-D45E5B2A8827}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Embedding.Wpf", "Embedding.Wpf\Embedding.Wpf.csproj", "{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Embedding.Wpf", "Embedding.Wpf\Embedding.Wpf.csproj", "{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.Console", "Example.Console\Example.Console.csproj", "{D6BE2FB0-7F05-4A90-8B66-B05C41CD775A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6BE2FB0-7F05-4A90-8B66-B05C41CD775A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6BE2FB0-7F05-4A90-8B66-B05C41CD775A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6BE2FB0-7F05-4A90-8B66-B05C41CD775A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6BE2FB0-7F05-4A90-8B66-B05C41CD775A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/Embedding.Wpf/App.xaml
+++ b/csharp/Embedding.Wpf/App.xaml
@@ -1,7 +1,7 @@
 ﻿<Application x:Class="Embedding.Wpf.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml" Startup="Application_Startup">
+             StartupUri="MainWindow.xaml">
     <Application.Resources>
          
     </Application.Resources>

--- a/csharp/Embedding.Wpf/App.xaml.cs
+++ b/csharp/Embedding.Wpf/App.xaml.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Windows;
-using System.Windows.Threading;
+﻿using System.Windows;
 
 namespace Embedding.Wpf
 {
@@ -10,22 +7,5 @@ namespace Embedding.Wpf
     /// </summary>
     public partial class App : Application
     {
-        private static readonly TraceSource Log = new TraceSource("Embedding.Wpf");
-
-        private void OnUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
-        {
-            e.Handled = true;
-            LogError($"Unhandled exception in main thread : {e.Exception}");
-        }
-
-        private void Application_Startup(object sender, StartupEventArgs e)
-        {
-            Current.DispatcherUnhandledException += OnUnhandledException;
-        }
-        private static void LogError(string message)
-        {
-            Console.Error.WriteLine(message);
-            Log.TraceEvent(TraceEventType.Error, 1, message);
-        }
     }
 }

--- a/csharp/Example.Console/Example.Console.csproj
+++ b/csharp/Example.Console/Example.Console.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNetBrowser" Version="2.16.0" />
+  </ItemGroup>
+
+</Project>

--- a/csharp/Example.Console/Program.cs
+++ b/csharp/Example.Console/Program.cs
@@ -20,6 +20,7 @@
 
 #endregion
 
+// #docfragment "Example.Console"
 using System;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
@@ -42,3 +43,4 @@ namespace Example.Console
         }
     }
 }
+// #enddocfragment "Example.Console"

--- a/csharp/Example.Console/Program.cs
+++ b/csharp/Example.Console/Program.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright
+
+// Copyright © 2022, TeamDev. All rights reserved.
+// 
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using DotNetBrowser.Browser;
+using DotNetBrowser.Engine;
+
+namespace Example.Console
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            using (IEngine engine = EngineFactory.Create())
+            {
+                IBrowser browser = engine.CreateBrowser();
+                browser.Navigation.LoadUrl("https://html5test.com/").Wait();
+                System.Console.WriteLine($"Web page title: {browser.Title}");
+            }
+
+            System.Console.WriteLine("Press any key to terminate...");
+            System.Console.ReadKey();
+        }
+    }
+}

--- a/vbnet/DotNetBrowser.QuickStart.sln
+++ b/vbnet/DotNetBrowser.QuickStart.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31829.152
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Embedding.WinForms", "Embedding.WinForms\Embedding.WinForms.vbproj", "{24C6C334-A4CF-4867-BA13-D45E5B2A8827}"
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Embedding.WinForms", "Embedding.WinForms\Embedding.WinForms.vbproj", "{24C6C334-A4CF-4867-BA13-D45E5B2A8827}"
 EndProject
-Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Embedding.Wpf", "Embedding.Wpf\Embedding.Wpf.vbproj", "{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}"
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Embedding.Wpf", "Embedding.Wpf\Embedding.Wpf.vbproj", "{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}"
+EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Example.Console", "Example.Console\Example.Console.vbproj", "{2746C707-5E27-4324-8529-FF4A588C63D4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59756E31-28CF-46D5-8CF1-43FD3F6ADB04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2746C707-5E27-4324-8529-FF4A588C63D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2746C707-5E27-4324-8529-FF4A588C63D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2746C707-5E27-4324-8529-FF4A588C63D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2746C707-5E27-4324-8529-FF4A588C63D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vbnet/Example.Console/Example.Console.vbproj
+++ b/vbnet/Example.Console/Example.Console.vbproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OptionExplicit>On</OptionExplicit>
+    <OptionCompare>Binary</OptionCompare>
+    <OptionStrict>Off</OptionStrict>
+    <OptionInfer>On</OptionInfer>
+    <RootNamespace />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNetBrowser" Version="2.16.0" />
+  </ItemGroup>
+
+</Project>

--- a/vbnet/Example.Console/Program.vb
+++ b/vbnet/Example.Console/Program.vb
@@ -1,0 +1,40 @@
+﻿#Region "Copyright"
+
+' Copyright © 2022, TeamDev. All rights reserved.
+' 
+' Redistribution and use in source and/or binary forms, with or without
+' modification, must retain the above copyright notice and the following
+' disclaimer.
+' 
+' THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+' "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+' LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+' A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+' OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+' SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+' LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+' DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+' THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+' (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#End Region
+
+Imports System
+Imports DotNetBrowser.Browser
+Imports DotNetBrowser.Engine
+
+Namespace Example.Console
+	Friend Class Program
+		Public Shared Sub Main(args() As String)
+			Using engine As IEngine = EngineFactory.Create()
+				Dim browser As IBrowser = engine.CreateBrowser()
+				browser.Navigation.LoadUrl("https://html5test.com/").Wait()
+				System.Console.WriteLine($"Web page title: {browser.Title}")
+			End Using
+
+			System.Console.WriteLine("Press any key to terminate...")
+			System.Console.ReadKey()
+		End Sub
+	End Class
+End Namespace

--- a/vbnet/Example.Console/Program.vb
+++ b/vbnet/Example.Console/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+' #docfragment "Example.Console"
 Imports System
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
@@ -38,3 +39,4 @@ Namespace Example.Console
 		End Sub
 	End Class
 End Namespace
+' #enddocfragment "Example.Console"


### PR DESCRIPTION
This PR adds an example that demonstrates how to use DotNetBrowser in console applications.

I'va also removed redundant exception handler in `Embedding.Wpf/App.xaml`. This exception handler swallows the actual exception that can happen during `IEngine` initialization. As a result, if the exception occurs, the application simply remains hanging in the Task Manager with no errors at all.