### PR TITLE
Switch quickstart to .NET 6. Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:0-6.0 AS dev 
+
+# XVFB and other dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        libgtk2.0-0 \
+        libgtk-3-0 \
+        libgbm-dev \
+        libnotify-dev \
+        libgconf-2-4 \
+        libnss3 \
+        libxss1 \
+        libasound2 \
+        libxtst6 \
+        xauth \
+        xvfb \
+        x11-xserver-utils
+
+ENV DISPLAY :0
+
+ADD xvfb_init /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends \
         libgtk2.0-0 \
         libgtk-3-0 \
-        libgbm-dev \
-        libnotify-dev \
+        libgbm1 \
+        libnotify4 \
         libgconf-2-4 \
         libnss3 \
         libxss1 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"hostRequirements": {
+		"cpus": 4,
+		"memory": "4gb",
+		"storage": "32gb" 
+	},
+	"features": {},
+
+	// Set DOTNETBROWSER_LICENSE for the whole container according to its value in the local environment.
+	// This also works with GitHub secrets with Codespaces.
+	"containerEnv": {
+		"DOTNETBROWSER_LICENSE": "${localEnv:DOTNETBROWSER_LICENSE}"
+	},
+	
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo /etc/init.d/xvfb start && dotnet tool restore"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,9 @@
 		"dockerfile": "Dockerfile"
 	},
 	"hostRequirements": {
-		"cpus": 4,
+		"cpus": 2,
 		"memory": "4gb",
-		"storage": "32gb" 
+		"storage": "12gb" 
 	},
 	"features": {},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,6 @@
 		"DOTNETBROWSER_LICENSE": "${localEnv:DOTNETBROWSER_LICENSE}"
 	},
 	
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sudo /etc/init.d/xvfb start && dotnet tool restore"
+	// Start Xvfb whenever the container is started.
+	"postStartCommand": "sudo /etc/init.d/xvfb start && dotnet tool restore"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "C# (.NET)",
+	"name": "DotNetBrowser (.NET 6)",
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
@@ -11,7 +11,8 @@
 	"features": {},
 
 	// Set DOTNETBROWSER_LICENSE for the whole container according to its value in the local environment.
-	// This also works with GitHub secrets with Codespaces.
+	// This can be used to pass the license key to DotNetBrowser.
+	// This also works if the license is stored in GitHub secrets.
 	"containerEnv": {
 		"DOTNETBROWSER_LICENSE": "${localEnv:DOTNETBROWSER_LICENSE}"
 	},

--- a/.devcontainer/xvfb_init
+++ b/.devcontainer/xvfb_init
@@ -1,0 +1,23 @@
+XVFB=/usr/bin/Xvfb
+XVFBARGS=":0 -ac -screen 0 1024x768x16"
+PIDFILE=/var/xvfb_0.pid
+case "$1" in
+  start)
+    echo -n "Starting virtual X frame buffer: Xvfb"
+    /sbin/start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile --background --exec $XVFB -- $XVFBARGS
+    echo "."
+    ;;
+  stop)
+    echo -n "Stopping virtual X frame buffer: Xvfb"
+    /sbin/start-stop-daemon --stop --quiet --pidfile $PIDFILE
+    echo "."
+    ;;
+  restart)
+    $0 stop
+    $0 start
+    ;;
+  *)
+  echo "Usage: /etc/init.d/xvfb {start|stop|restart}"
+  exit 1
+esac
+exit 0

--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,4 @@
 *.filters text eol=crlf
 
 *.patch eol=lf
+*.sh eol=lf

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the examples for the [Quick Start](https://dotnetbrowse
 
 ## Prerequisites
 Make sure your environment meets the
-[software and hardware requirements](https://dotnetbrowser-support.teamdev.com/docs/guides/requirements.html). Additionally, .NET Core SDK 3.1 or higher must be installed.
+[software and hardware requirements](https://dotnetbrowser-support.teamdev.com/docs/guides/requirements.html). Additionally, .NET 6 SDK or higher must be installed.
 
 Request a free 30-day evaluation license key via the [web form](https://www.teamdev.com/dotnetbrowser#evaluate).
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ dotnet cake --lang="csharp" --ui="wpf" --license-key="your_license_key"
 
 This repository contains the development container (devcontainer) configuration that can be used to easily create a Linux-based development environment and work with DotNetBrowser there.
 
-You can use any of the [supported tools](https://containers.dev/supporting) to create a devcontainer and work with it. After the container is ready and the post-create command is executed, you can use the steps from the section above to build and run an example.
+You can use any of the [supported tools](https://containers.dev/supporting) to create a devcontainer and work with it. After the container is ready and the post-create command is executed, you can use the steps from the section above to build and run an example:
 
-*Note*: Linux environments do not support WPF or Windows Forms, so, only the console example can be used in this environment.
+```
+dotnet tool restore
+dotnet cake --lang="csharp" --ui="console" --license-key="your_license_key"
+```
+
+*Note*: Development container is a headless Linux environment, and these environments do not support WPF or Windows Forms. Therefore, only the console example can be used.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ dotnet cake --lang="csharp" --ui="wpf" --license-key="your_license_key"
  - `--license-key` Required. The license key used for launching the application.
  - `--lang` Optional. Can be either `csharp` or `vbnet`. The default value is `csharp`.
  - `--ui` Optional. Can be either `console`, `wpf`, or `winforms`. The default value is `console`.
+
+## Development container
+
+This repository contains the development container (devcontainer) configuration that can be used to easily create a Linux-based development environment and work with DotNetBrowser there.
+
+You can use any of the [supported tools](https://containers.dev/supporting) to create a devcontainer and work with it. After the container is ready and the post-create command is executed, you can use the steps from the section above to build and run an example.
+
+*Note*: Linux environments do not support WPF or Windows Forms, so, only the console example can be used in this environment.

--- a/csharp/Embedding.WinForms/Embedding.WinForms.csproj
+++ b/csharp/Embedding.WinForms/Embedding.WinForms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
     <UseWindowsForms Condition="'$(OS)' == 'Windows_NT'">true</UseWindowsForms>
     <AssemblyName>Embedding.WinForms</AssemblyName>
   </PropertyGroup>

--- a/csharp/Embedding.WinForms/Embedding.WinForms.csproj
+++ b/csharp/Embedding.WinForms/Embedding.WinForms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <UseWindowsForms Condition="'$(OS)' == 'Windows_NT'">true</UseWindowsForms>
     <AssemblyName>Embedding.WinForms</AssemblyName>
   </PropertyGroup>

--- a/csharp/Embedding.Wpf/Embedding.Wpf.csproj
+++ b/csharp/Embedding.Wpf/Embedding.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <UseWpf Condition="'$(OS)' == 'Windows_NT'">true</UseWpf>
     <AssemblyName>Embedding.Wpf</AssemblyName>
     <RootNamespace>Embedding.Wpf</RootNamespace>

--- a/csharp/Embedding.Wpf/Embedding.Wpf.csproj
+++ b/csharp/Embedding.Wpf/Embedding.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
     <UseWpf Condition="'$(OS)' == 'Windows_NT'">true</UseWpf>
     <AssemblyName>Embedding.Wpf</AssemblyName>
     <RootNamespace>Embedding.Wpf</RootNamespace>

--- a/csharp/Example.Console/Example.Console.csproj
+++ b/csharp/Example.Console/Example.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Label="Build on Unix" Condition="'$(OS)' == 'Unix'">

--- a/vbnet/Embedding.WinForms/Embedding.WinForms.vbproj
+++ b/vbnet/Embedding.WinForms/Embedding.WinForms.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
     <UseWindowsForms Condition="'$(OS)' == 'Windows_NT'">true</UseWindowsForms>
     <AssemblyName>Embedding.WinForms</AssemblyName>
   </PropertyGroup>

--- a/vbnet/Embedding.WinForms/Embedding.WinForms.vbproj
+++ b/vbnet/Embedding.WinForms/Embedding.WinForms.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <UseWindowsForms Condition="'$(OS)' == 'Windows_NT'">true</UseWindowsForms>
     <AssemblyName>Embedding.WinForms</AssemblyName>
   </PropertyGroup>

--- a/vbnet/Embedding.Wpf/Embedding.Wpf.vbproj
+++ b/vbnet/Embedding.Wpf/Embedding.Wpf.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <UseWpf Condition="'$(OS)' == 'Windows_NT'">true</UseWpf>
     <AssemblyName>Embedding.Wpf</AssemblyName>
     <RootNamespace>Embedding.Wpf</RootNamespace>

--- a/vbnet/Embedding.Wpf/Embedding.Wpf.vbproj
+++ b/vbnet/Embedding.Wpf/Embedding.Wpf.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
     <UseWpf Condition="'$(OS)' == 'Windows_NT'">true</UseWpf>
     <AssemblyName>Embedding.Wpf</AssemblyName>
     <RootNamespace>Embedding.Wpf</RootNamespace>

--- a/vbnet/Example.Console/Example.Console.vbproj
+++ b/vbnet/Example.Console/Example.Console.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>


### PR DESCRIPTION
This PR switches all the projects in this repository to .NET 6 and adds a development container configuration that can be used with Docker or Codespaces.