### PR TITLE
Load documentation portal instead of HTML5 test

### DIFF
--- a/csharp/Embedding.WinForms/Form1.cs
+++ b/csharp/Embedding.WinForms/Form1.cs
@@ -34,7 +34,7 @@ namespace Embedding.WinForms
     /// </summary>
     public partial class Form1 : Form
     {
-        private const string Url = "https://html5test.com/";
+        private const string Url = "https://dotnetbrowser-support.teamdev.com/";
         private readonly IBrowser browser;
         private readonly IEngine engine;
 

--- a/csharp/Embedding.Wpf/MainWindow.xaml.cs
+++ b/csharp/Embedding.Wpf/MainWindow.xaml.cs
@@ -34,7 +34,7 @@ namespace Embedding.Wpf
     /// </summary>
     public partial class MainWindow : Window
     {
-        private const string Url = "https://html5test.com/";
+        private const string Url = "https://dotnetbrowser-support.teamdev.com/";
         private readonly IBrowser browser;
         private readonly IEngine engine;
 

--- a/vbnet/Embedding.WinForms/Form1.vb
+++ b/vbnet/Embedding.WinForms/Form1.vb
@@ -34,7 +34,7 @@ Namespace Embedding.WinForms
     Partial Public Class Form1
         Inherits Form
 
-        Private Const Url As String = "https://html5test.com/"
+        Private Const Url As String = "https://dotnetbrowser-support.teamdev.com/"
         Private ReadOnly browser As IBrowser
         Private ReadOnly engine As IEngine
 

--- a/vbnet/Embedding.Wpf/MainWindow.xaml.vb
+++ b/vbnet/Embedding.Wpf/MainWindow.xaml.vb
@@ -33,7 +33,7 @@ Namespace Embedding.Wpf
     Partial Public Class MainWindow
         Inherits Window
 
-        Private Const Url As String = "https://html5test.com/"
+        Private Const Url As String = "https://dotnetbrowser-support.teamdev.com/"
         Private ReadOnly browser As IBrowser
         Private ReadOnly engine As IEngine
 


### PR DESCRIPTION
In this changeset, we change the website our customer sees when launches DotNetBrowser for the first time.

Why?

* It doesn't make sense anymore to prove we're HTML5 compatible. 

* We lead a customer to their next step: discover some features, learn more about the product.