### PR TITLE
Improve sample titles and console identification

### DIFF
--- a/csharp/Embedding.Avalonia/MainWindow.axaml
+++ b/csharp/Embedding.Avalonia/MainWindow.axaml
@@ -5,6 +5,6 @@
         xmlns:app="clr-namespace:DotNetBrowser.AvaloniaUi;assembly=DotNetBrowser.AvaloniaUi"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="Embedding.AvaloniaUi.MainWindow"
-        Title="Embedding.AvaloniaUi" Closed="Window_Closed">
+        Title="DotNetBrowser — Avalonia" Closed="Window_Closed">
     <app:BrowserView x:Name="BrowserView"/>
 </Window>

--- a/csharp/Embedding.WinForms/Form1.Designer.cs
+++ b/csharp/Embedding.WinForms/Form1.Designer.cs
@@ -32,7 +32,7 @@ namespace Embedding.WinForms
             this.components = new System.ComponentModel.Container();
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Text = "Form1";
+            this.Text = "DotNetBrowser — Windows Forms";
         }
 
         #endregion

--- a/csharp/Embedding.Wpf/MainWindow.xaml
+++ b/csharp/Embedding.Wpf/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:WPF="clr-namespace:DotNetBrowser.Wpf;assembly=DotNetBrowser.Wpf"
     x:Class="Embedding.Wpf.MainWindow"
     mc:Ignorable="d"
-    Title="MainWindow" Height="480" Width="800" Closed="Window_Closed">
+    Title="DotNetBrowser — WPF" Height="480" Width="800" Closed="Window_Closed">
     <Grid>
         <WPF:BrowserView Name="browserView" />
     </Grid>

--- a/csharp/Example.Console/Program.cs
+++ b/csharp/Example.Console/Program.cs
@@ -26,7 +26,7 @@ using DotNetBrowser.Browser;
 using DotNetBrowser.Dom;
 using DotNetBrowser.Engine;
 
-Console.Title = "DotNetBrowser";
+Console.Title = "DotNetBrowser — Console";
 EngineOptions.Builder builder = new EngineOptions.Builder();
 // Uncomment the line below to specify your license key
 // builder.LicenseKey = "your_license_key";

--- a/csharp/Example.Console/Program.cs
+++ b/csharp/Example.Console/Program.cs
@@ -26,6 +26,7 @@ using DotNetBrowser.Browser;
 using DotNetBrowser.Dom;
 using DotNetBrowser.Engine;
 
+Console.Title = "DotNetBrowser";
 EngineOptions.Builder builder = new EngineOptions.Builder();
 // Uncomment the line below to specify your license key
 // builder.LicenseKey = "your_license_key";
@@ -43,4 +44,6 @@ using (IEngine engine = EngineFactory.Create(builder.Build()))
     Console.WriteLine(quote);
     Console.WriteLine($"— {author}");
 }
+
+Console.ReadKey();
 // #enddocfragment "Example.Console"

--- a/vbnet/Embedding.Avalonia/MainWindow.axaml
+++ b/vbnet/Embedding.Avalonia/MainWindow.axaml
@@ -5,6 +5,6 @@
         xmlns:app="clr-namespace:DotNetBrowser.AvaloniaUi;assembly=DotNetBrowser.AvaloniaUi"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="Embedding.Avalonia.MainWindow"
-        Title="Embedding.Avalonia" Closed="Window_Closed">
+        Title="DotNetBrowser — Avalonia" Closed="Window_Closed">
     <app:BrowserView x:Name="BrowserView"/>
 </Window>

--- a/vbnet/Embedding.WinForms/Form1.Designer.vb
+++ b/vbnet/Embedding.WinForms/Form1.Designer.vb
@@ -26,7 +26,7 @@ Namespace Embedding.WinForms
 			Me.components = New System.ComponentModel.Container()
 			Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
 			Me.ClientSize = New System.Drawing.Size(800, 450)
-			Me.Text = "Form1"
+			Me.Text = "DotNetBrowser — Windows Forms"
 		End Sub
 
 		#End Region

--- a/vbnet/Embedding.Wpf/MainWindow.xaml
+++ b/vbnet/Embedding.Wpf/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:WPF="clr-namespace:DotNetBrowser.Wpf;assembly=DotNetBrowser.Wpf"
     x:Class="Embedding.Wpf.MainWindow"
     mc:Ignorable="d"
-    Title="MainWindow" Height="480" Width="800" Closed="Window_Closed">
+    Title="DotNetBrowser — WPF" Height="480" Width="800" Closed="Window_Closed">
     <Grid>
         <WPF:BrowserView Name="browserView" />
     </Grid>

--- a/vbnet/Example.Console/Program.vb
+++ b/vbnet/Example.Console/Program.vb
@@ -26,6 +26,7 @@ Imports DotNetBrowser.Engine
 
 Module Program
     Sub Main(args() As String)
+        Console.Title = "DotNetBrowser"
         Dim builder = new EngineOptions.Builder()
         ' Uncomment the line below to specify your license key
         ' builder.LicenseKey = "your_license_key"
@@ -43,6 +44,8 @@ Module Program
             System.Console.WriteLine(quote)
             System.Console.WriteLine($"— {author}")
         End Using
+
+        Console.ReadKey()
     End Sub
 End Module
 ' #enddocfragment "Example.Console"

--- a/vbnet/Example.Console/Program.vb
+++ b/vbnet/Example.Console/Program.vb
@@ -26,7 +26,7 @@ Imports DotNetBrowser.Engine
 
 Module Program
     Sub Main(args() As String)
-        Console.Title = "DotNetBrowser"
+        Console.Title = "DotNetBrowser — Console"
         Dim builder = new EngineOptions.Builder()
         ' Uncomment the line below to specify your license key
         ' builder.LicenseKey = "your_license_key"


### PR DESCRIPTION
- Rename window/form titles across all samples to include "DotNetBrowser" (WPF: "DotNetBrowser — WPF", WinForms: "DotNetBrowser — Windows Forms", Avalonia: "DotNetBrowser — Avalonia")
- Set Console.Title = "DotNetBrowser" in the console sample
- Add Console.ReadKey() so the console window stays open for screenshots